### PR TITLE
add ability to handle V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,12 @@ swaggerChangeLog {
     // (optional) from what level should the chapters 
     // start at. By default, they will start at level 3, 
     // i.e. "==="
-    baseChapterLevel = 3    
+    baseChapterLevel = 3
+
+    // (optional) the app assumes, for backwards-compatibility
+    // reasons that the target nexus is version 2set this to true
+    // if the target is version 3+
+    isNexusVersion3 = true
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
   repositories {
+    jcenter()
     maven { url "http://repo.spring.io/libs-release" }
     mavenCentral()
   }
@@ -40,6 +41,7 @@ ext.isForPluginPublishing = isParameterDefined('gradle.publish.key') && isParame
 
 
 repositories {
+  jcenter()
   mavenCentral()
   maven { url "https://repo.spring.io/plugins-release/" }
   maven { url "https://maven.geomajas.org/" }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,10 @@ plugins {
   id 'java-gradle-plugin'
   id 'com.gradle.plugin-publish' version '0.12.0'
   id "io.freefair.lombok" version "4.1.6"
-
+}
+repositories {
+  mavenCentral()
+  jcenter()
 }
 group = 'com.sonalake'
 version = '1.0.4-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ configurations.all {
 }
 dependencies {
 
+  // I don't know why they don't just add this into java ;)
+  compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+
   // used to get data from nexus, and turn results into POJOs
   compile group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 // a parameter is defined if it's been passed in and isn't blank
-ext.isParameterDefined = { String paramName->
+ext.isParameterDefined = { String paramName ->
   return project.hasProperty(paramName) && !project.getProperties().get(paramName).toString().isBlank();
 }
 
@@ -32,7 +32,6 @@ ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 ext.isForPluginPublishing = isParameterDefined('gradle.publish.key') && isParameterDefined('gradle.publish.secret')
 
 
-
 repositories {
   mavenCentral()
   maven { url "https://repo.spring.io/plugins-release/" }
@@ -44,18 +43,19 @@ configurations.all {
 }
 dependencies {
 
-   // used to get data from nexus, and turn results into POJOs
+  // used to get data from nexus, and turn results into POJOs
   compile group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
+
 
   // diff the swagger jsons, and translate the MD to asciidoc
   compile group: 'com.deepoove', name: 'swagger-diff', version: '1.2.1'
   compile group: 'nl.jworks.markdown_to_asciidoc', name: 'markdown_to_asciidoc', version: '1.1'
 
+
   // used to sort versions
   compile 'se.sawano.java:alphanumeric-comparator:1.4.1'
-
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
@@ -107,7 +107,6 @@ gradlePlugin {
     }
   }
 }
-
 
 
 signing {
@@ -164,8 +163,6 @@ if (isForOssrhPublishing) {
     }
   }
 }
-
-
 
 
 // we can only release final versions here

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+  repositories {
+    maven { url "http://repo.spring.io/libs-release" }
+    mavenCentral()
+  }
+}
+
 plugins {
   id 'java'
   id 'com.github.kt3k.coveralls' version '2.10.1'
@@ -5,10 +12,7 @@ plugins {
   id 'com.gradle.plugin-publish' version '0.12.0'
   id "io.freefair.lombok" version "4.1.6"
 }
-repositories {
-  mavenCentral()
-  jcenter()
-}
+
 group = 'com.sonalake'
 version = '1.0.4-SNAPSHOT'
 sourceCompatibility = '11'

--- a/src/main/java/com/sonalake/swaggerlog/config/Config.java
+++ b/src/main/java/com/sonalake/swaggerlog/config/Config.java
@@ -37,11 +37,11 @@ public class Config {
   // if this is set, it will be considered the _last_ version in the history
   private String snapshotVersionFile;
 
-  public String getNexusSearchPath() {
-    return nexusHome + "/service/local/lucene/search";
-  }
-
-  public String getNexusDownloadPath(String repository) {
-    return nexusHome + "/service/local/repositories/" + repository + "/content";
-  }
+  /**
+   * By default the tool will assume a V2 of the nexus search/download API, but setting this
+   * to true will tell it to use the V3 of the API
+   */
+  private boolean isVersion3;
 }
+
+

--- a/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
+++ b/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 
 import static com.deepoove.swagger.diff.SwaggerDiff.compareV2;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * Given the config, collect and sort the swaggers from nexus, and produce both the diffs and their index file.

--- a/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
+++ b/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
+import org.gradle.internal.impldep.org.codehaus.plexus.util.FileUtils;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -45,8 +46,9 @@ public class LogGenerator {
       .map(step -> buildSwaggerDiff(scanner, step))
       .filter(this::skipStepsWithNoChanges)
       .forEach(diff -> appendDiffToChangelog(index, diff));
-
+    guaranteeIndexFile(index);
   }
+
 
   /**
    * Build a difference-model between the two versions in the give step
@@ -81,6 +83,21 @@ public class LogGenerator {
       log.debug("No diff for {} -> {}", diff.getOldVersion(), diff.getNewVersion());
     }
     return !hasNoChanges;
+  }
+
+  /**
+   * If we have no results, we want to write an empty changelog to show this
+   *
+   * @param index
+   */
+  private void guaranteeIndexFile(Path index) throws IOException {
+    if (!FileUtils.fileExists(index.toAbsolutePath().toString()))
+      Files.write(
+        index,
+        "No change history available".getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND
+      );
   }
 
   /**

--- a/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
+++ b/src/main/java/com/sonalake/swaggerlog/diff/LogGenerator.java
@@ -60,6 +60,7 @@ public class LogGenerator {
     String fromUri = scanner.getVersionUri(step.getFrom());
     String toUri = scanner.getVersionUri(step.getTo());
 
+    System.out.println(String.format("Diffing %s -> %s", fromUri, toUri));
     log.debug("Diffing urls {} -> {}", fromUri, toUri);
 
     return compareV2(fromUri, toUri);

--- a/src/main/java/com/sonalake/swaggerlog/gradle/ChangelogExtension.java
+++ b/src/main/java/com/sonalake/swaggerlog/gradle/ChangelogExtension.java
@@ -57,10 +57,12 @@ public class ChangelogExtension {
 
   /**
    * Path to the optional shapshot version file. This is the current, not as-yet released swagger.
-   *
+   * <p>
    * If this is set, it will be considered the _last_ version in the history
    */
   private String snapshotVersionFile;
+
+  private Boolean isNexusVersion3;
 
   public String getRepositoryId() {
     return repositoryId == null ? "releases" : repositoryId;
@@ -73,6 +75,7 @@ public class ChangelogExtension {
       .target(buildTarget())
       .snapshotVersionFile(getSnapshotVersionFile())
       .artifact(buildArtifact())
+      .isVersion3(Boolean.TRUE.equals(isNexusVersion3))
       .build();
   }
 

--- a/src/main/java/com/sonalake/swaggerlog/nexus/SearchResults.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/SearchResults.java
@@ -1,7 +1,5 @@
 package com.sonalake.swaggerlog.nexus;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -12,14 +10,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 class SearchResults {
   @Singular
-  @JsonProperty("data")
+
   private List<VersionedArtifact> versions;
+
 
   public List<VersionStep> buildHistory() {
 
@@ -51,7 +49,5 @@ class SearchResults {
     return steps;
   }
 
-  public void addSnapshot(VersionedArtifact snapshot) {
-    versions.add(snapshot);
-  }
+
 }

--- a/src/main/java/com/sonalake/swaggerlog/nexus/VersionedArtifact.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/VersionedArtifact.java
@@ -32,6 +32,8 @@ public class VersionedArtifact implements Comparable<VersionedArtifact> {
   @JsonProperty("version")
   private String version;
 
+  private String downloadFrom;
+
   private String path;
 
   /**

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
@@ -1,0 +1,19 @@
+package com.sonalake.swaggerlog.nexus.formats;
+
+import com.sonalake.swaggerlog.config.Config;
+import com.sonalake.swaggerlog.nexus.VersionedArtifact;
+
+import java.util.List;
+
+/**
+ * A generic interface for the nexus search results
+ */
+public interface NexusResult {
+  /**
+   * Given a config, map the raw json results to a list of versioned artifacts
+   *
+   * @param config the configuration
+   * @return the versioned artifacts
+   */
+  List<VersionedArtifact> buildVersions(Config config);
+}

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
@@ -16,4 +16,9 @@ public interface NexusResult {
    * @return the versioned artifacts
    */
   List<VersionedArtifact> buildVersions(Config config);
+
+  /**
+   * Check if there's enough data in here to do anything
+   */
+  void validate() throws AssertionError;
 }

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/NexusResult.java
@@ -17,8 +17,4 @@ public interface NexusResult {
    */
   List<VersionedArtifact> buildVersions(Config config);
 
-  /**
-   * Check if there's enough data in here to do anything
-   */
-  void validate() throws AssertionError;
 }

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
@@ -1,0 +1,144 @@
+package com.sonalake.swaggerlog.nexus.formats;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sonalake.swaggerlog.config.Config;
+import com.sonalake.swaggerlog.nexus.VersionedArtifact;
+import lombok.Data;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+/**
+ * Jackson will map the raw JSON from a V2 query to this class
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class V2NexusResult implements NexusResult {
+  @JsonProperty("repoDetails")
+  private List<Repo> repoDetails;
+
+  @JsonProperty("data")
+  private List<Item> items;
+
+  /**
+   * %{@inheritDoc}
+   */
+  @Override
+  public List<VersionedArtifact> buildVersions(Config config) {
+    // we derive our download URLs from this part of the result
+    Map<String, Repo> repos = repoDetails.stream().collect(Collectors.toMap(
+      Repo::getRepositoryId,
+      v -> v
+    ));
+
+    // now map the items to a versioned artifact, each will contain a download URL
+    // based on the classifer (or the first json entry) in the underlying "artifact hits"
+    return items
+      .stream()
+      .map(i -> {
+
+        String downloadFrom = buildDownloadUrl(config.getArtifact().getClassifier(), repos, i);
+        return VersionedArtifact.builder()
+          .artifact(i.getArtifactId())
+          .version(i.getVersion())
+          .group(i.getGroupId())
+          .downloadFrom(downloadFrom)
+          .build();
+      }).collect(Collectors.toList());
+
+  }
+
+
+  private String buildDownloadUrl(String classifier, Map<String, Repo> repos, Item i) {
+    return i.findLinkForClassifier(classifier).map(link -> {
+        List<String> path = new ArrayList<>();
+        path.add(repos.get(link.getRepositoryId()).getRepositoryURL());
+        path.add("content");
+        path.addAll(asList(i.getGroupId().split("\\.")));
+        path.add(i.getArtifactId());
+        path.add(i.getVersion());
+
+        String classifierAppendage = isNotEmpty(classifier) ?
+          "-" + classifier
+          : "";
+
+        path.add(format("%s-%s%s.json",
+          i.getArtifactId(),
+          i.getVersion(),
+          classifierAppendage
+        ));
+        return join("/", path);
+      }
+    ).orElse(null);
+  }
+
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Repo {
+    @JsonProperty("repositoryId")
+    private String repositoryId;
+    @JsonProperty("repositoryURL")
+    private String repositoryURL;
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Item {
+    private String groupId;
+    private String artifactId;
+    private String version;
+
+    @JsonProperty("artifactHits")
+    private List<ArtifactHit> artifactHits;
+
+    /**
+     * Find the artifact link that matches this classifier. It will find the first json entry
+     * if the parameter is null or empty.
+     *
+     * @param classifier the classifier of interest
+     * @return the matching link - this will be enriched with the repo id
+     */
+    public Optional<ArtifactLink> findLinkForClassifier(String classifier) {
+
+      // if there is a classifier, then use it, otherwise we use the first json
+      Predicate<ArtifactLink> checker = isNotEmpty(classifier) ?
+        link -> Objects.equals(classifier, link.getClassifier())
+        : link -> "json" .equals(link.getExtension());
+
+      for (ArtifactHit hit : artifactHits) {
+        for (ArtifactLink link : hit.getArtifactLinks()) {
+          if (checker.test(link)) {
+            link.setRepositoryId(hit.getRepositoryId());
+            return Optional.ofNullable(link);
+          }
+        }
+      }
+
+      return Optional.empty();
+    }
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class ArtifactHit {
+    private String repositoryId;
+    @JsonProperty("artifactLinks")
+    private List<ArtifactLink> artifactLinks;
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class ArtifactLink {
+    private String classifier;
+    private String extension;
+    private String repositoryId;
+  }
+}

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
@@ -10,10 +10,10 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Iterables.isEmpty;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
@@ -34,14 +34,14 @@ public class V2NexusResult implements NexusResult {
   @Override
   public List<VersionedArtifact> buildVersions(Config config) {
     // we derive our download URLs from this part of the result
-    Map<String, Repo> repos = repoDetails.stream().collect(Collectors.toMap(
+    Map<String, Repo> repos = emptyIfNull(repoDetails).stream().collect(Collectors.toMap(
       Repo::getRepositoryId,
       v -> v
     ));
 
     // now map the items to a versioned artifact, each will contain a download URL
-    // based on the classifer (or the first json entry) in the underlying "artifact hits"
-    return items
+    // based on the classifier (or the first json entry) in the underlying "artifact hits"
+    return emptyIfNull(items)
       .stream()
       .map(i -> {
 
@@ -54,16 +54,6 @@ public class V2NexusResult implements NexusResult {
           .build();
       }).collect(Collectors.toList());
 
-  }
-
-  @Override
-  public void validate() throws AssertionError {
-    if (null == this.getRepoDetails() || this.getRepoDetails().isEmpty()) {
-      throw new AssertionError("There are no repo details in the response");
-    }
-    if (null == this.getItems() || this.getItems().isEmpty()) {
-      throw new AssertionError("There are no items details in the response");
-    }
   }
 
 
@@ -122,9 +112,9 @@ public class V2NexusResult implements NexusResult {
       // if there is a classifier, then use it, otherwise we use the first json
       Predicate<ArtifactLink> checker = isNotEmpty(classifier) ?
         link -> Objects.equals(classifier, link.getClassifier())
-        : link -> "json" .equals(link.getExtension());
+        : link -> "json".equals(link.getExtension());
 
-      for (ArtifactHit hit : artifactHits) {
+      for (ArtifactHit hit : emptyIfNull(artifactHits)) {
         for (ArtifactLink link : hit.getArtifactLinks()) {
           if (checker.test(link)) {
             link.setRepositoryId(hit.getRepositoryId());

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V2NexusResult.java
@@ -10,6 +10,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.Iterables.isEmpty;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
@@ -53,6 +54,16 @@ public class V2NexusResult implements NexusResult {
           .build();
       }).collect(Collectors.toList());
 
+  }
+
+  @Override
+  public void validate() throws AssertionError {
+    if (null == this.getRepoDetails() || this.getRepoDetails().isEmpty()) {
+      throw new AssertionError("There are no repo details in the response");
+    }
+    if (null == this.getItems() || this.getItems().isEmpty()) {
+      throw new AssertionError("There are no items details in the response");
+    }
   }
 
 

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.Iterables.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 
@@ -45,6 +46,13 @@ public class V3NexusResult implements NexusResult {
           .build();
       })
       .collect(Collectors.toList());
+  }
+
+  @Override
+  public void validate() throws AssertionError {
+    if (isEmpty(this.items)) {
+      throw new AssertionError("There are no items details in the response");
+    }
   }
 
 

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
@@ -1,0 +1,70 @@
+package com.sonalake.swaggerlog.nexus.formats;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sonalake.swaggerlog.config.Config;
+import com.sonalake.swaggerlog.nexus.VersionedArtifact;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class V3NexusResult implements NexusResult {
+
+  @JsonProperty("items")
+  private List<Item> items;
+
+
+  /**
+   * ${@inheritDoc}
+   */
+  @Override
+  public List<VersionedArtifact> buildVersions(Config config) {
+    // if there is a classifier, then use it, otherwise we use the first json
+    String filenameSuffix = isNotEmpty(config.getArtifact().getClassifier())
+      ? String.format("-%s.json", config.getArtifact().getClassifier())
+      : ".json";
+
+    // this is _much_ easier than V2, because this result contains the asset download URL
+    return items.stream()
+      .map(i -> {
+        String downloadFrom = i.assets.stream().filter(a -> a.getPath().endsWith(filenameSuffix))
+          .findFirst()
+          .map(Asset::getDownloadUrl)
+          .orElse(null);
+        return VersionedArtifact.builder()
+          .group(i.getGroup())
+          .version(i.getVersion())
+          .artifact(i.getName())
+          .downloadFrom(downloadFrom)
+          .build();
+      })
+      .collect(Collectors.toList());
+  }
+
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Item {
+    private String group;
+    private String name;
+    private String version;
+    @JsonProperty("assets")
+    private List<Asset> assets;
+
+
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  private static class Asset {
+    private String path;
+    private String downloadUrl;
+
+  }
+}

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/V3NexusResult.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Iterables.isEmpty;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 
@@ -32,9 +33,9 @@ public class V3NexusResult implements NexusResult {
       : ".json";
 
     // this is _much_ easier than V2, because this result contains the asset download URL
-    return items.stream()
+    return emptyIfNull(items).stream()
       .map(i -> {
-        String downloadFrom = i.assets.stream().filter(a -> a.getPath().endsWith(filenameSuffix))
+        String downloadFrom = emptyIfNull(i.assets).stream().filter(a -> a.getPath().endsWith(filenameSuffix))
           .findFirst()
           .map(Asset::getDownloadUrl)
           .orElse(null);
@@ -46,13 +47,6 @@ public class V3NexusResult implements NexusResult {
           .build();
       })
       .collect(Collectors.toList());
-  }
-
-  @Override
-  public void validate() throws AssertionError {
-    if (isEmpty(this.items)) {
-      throw new AssertionError("There are no items details in the response");
-    }
   }
 
 

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/VersionFinder.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/VersionFinder.java
@@ -1,0 +1,72 @@
+package com.sonalake.swaggerlog.nexus.formats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.mashape.unirest.request.HttpRequest;
+import com.sonalake.swaggerlog.config.Config;
+import com.sonalake.swaggerlog.nexus.VersionedArtifact;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+@Slf4j
+public class VersionFinder {
+
+  public List<VersionedArtifact> findVersions(Config config) {
+    try {
+      if (config.isVersion3()) {
+        return findNexus3Versions(config);
+      } else {
+        return findNexus2Versions(config);
+      }
+
+    } catch (UnirestException | IOException e) {
+      throw new IllegalArgumentException("Failed to parse results from nexus: " + config, e);
+    }
+
+  }
+
+
+  private List<VersionedArtifact> findNexus3Versions(Config config) throws UnirestException, IOException {
+    HttpRequest builder = Unirest.get(config.getNexusHome() + "/service/local/lucene/search")
+      .header("accept", "application/json")
+      .queryString("repository", config.getRepositoryId())
+      .queryString("group", config.getArtifact().getGroupId())
+      .queryString("maven.artifactId", config.getArtifact().getArtifactId())
+      .queryString("maven.extension", "json");
+
+    if (isNotBlank(config.getArtifact().getClassifier())) {
+      builder.queryString("maven.classifier", config.getArtifact().getClassifier());
+    }
+
+    return parseNexusResults(builder.asString(), V3NexusResult.class, config);
+  }
+
+  private List<VersionedArtifact> findNexus2Versions(Config config) throws UnirestException, IOException {
+    HttpRequest builder = Unirest.get(config.getNexusHome() + "/service/rest/v1/search")
+      .header("accept", "application/json")
+      .queryString("g", config.getArtifact().getGroupId())
+      .queryString("a", config.getArtifact().getArtifactId())
+      .queryString("p", "json")
+      .queryString("repositoryId", config.getRepositoryId());
+
+    if (isNotBlank(config.getArtifact().getClassifier())) {
+      builder.queryString("c", config.getArtifact().getClassifier());
+    }
+
+
+    return parseNexusResults(builder.asString(), V2NexusResult.class, config);
+  }
+
+
+  private <T extends NexusResult> List<VersionedArtifact> parseNexusResults(HttpResponse<String> result, Class<T> format, Config config) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    T resultObject = mapper.readValue(result.getBody(), format);
+    return resultObject.buildVersions(config);
+  }
+}

--- a/src/main/java/com/sonalake/swaggerlog/nexus/formats/VersionFinder.java
+++ b/src/main/java/com/sonalake/swaggerlog/nexus/formats/VersionFinder.java
@@ -60,7 +60,7 @@ public class VersionFinder {
     }
 
     HttpResponse<String> result = builder.asString();
-    if (result.getStatus() >=400) {
+    if (result.getStatus() >= 400) {
       throw new AssertionError(String.format("Request for config rejected (%s) by nexus: %s", result.getStatusText(), config));
     }
 
@@ -72,7 +72,6 @@ public class VersionFinder {
   private <T extends NexusResult> List<VersionedArtifact> parseNexusResults(HttpResponse<String> result, Class<T> format, Config config) throws IOException {
     ObjectMapper mapper = new ObjectMapper();
     T resultObject = mapper.readValue(result.getBody(), format);
-    resultObject.validate();
     return resultObject.buildVersions(config);
   }
 }

--- a/src/test/java/com/sonalake/swaggerlog/diff/LogGeneratorTest.java
+++ b/src/test/java/com/sonalake/swaggerlog/diff/LogGeneratorTest.java
@@ -125,6 +125,11 @@ public class LogGeneratorTest {
   }
 
   private VersionedArtifact artifact(String version) {
-    return VersionedArtifact.builder().group("groupA").artifact("thisIsId").version(version).build();
+    return VersionedArtifact.builder()
+      .group("groupA")
+      .artifact("thisIsId")
+      .version(version)
+      .downloadFrom(String.format("http://nexus/there/groupA/thisIsId/%s/thisIsId-%s.json", version, version))
+      .build();
   }
 }

--- a/src/test/java/com/sonalake/swaggerlog/diff/LogGeneratorTest.java
+++ b/src/test/java/com/sonalake/swaggerlog/diff/LogGeneratorTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -114,6 +115,41 @@ public class LogGeneratorTest {
       files
     );
 
+  }
+
+  @Test
+  public void testWithNoVersionData() throws Exception {
+    mockStatic(SwaggerDiff.class);
+    Config config = Config.builder()
+      .artifact(Artifact.builder()
+        .groupId("groupy")
+        .artifactId("covenant")
+        .build())
+      .nexusHome("http://nexus/there")
+      .target(Target.builder().targetdir(Files.createTempDirectory("LogGeneratorTest").toString()).build())
+      .build();
+
+    Scanner scanner = spy(Scanner.builder()
+      .config(config)
+      .build());
+
+    // given no history
+    doReturn(emptyList()).when(scanner).getHistory();
+
+    LogGenerator generator = spy(LogGenerator.builder().config(config).build());
+    doReturn(scanner).when(generator).buildScanner();
+
+    generator.generateChangeLog();
+
+    log.debug(config.getTarget().getTargetdir());
+
+    List<String> files = Files.readAllLines(Paths.get(config.getTarget().getTargetdir(), LogGenerator.CHANGE_LOG_ADOC));
+    assertEquals(
+      asList(
+        "No change history available"
+      ),
+      files
+    );
   }
 
   private Endpoint get(String path, String summary) {

--- a/src/test/java/com/sonalake/swaggerlog/nexus/ScannerTest.java
+++ b/src/test/java/com/sonalake/swaggerlog/nexus/ScannerTest.java
@@ -7,14 +7,18 @@ import com.mashape.unirest.request.GetRequest;
 import com.sonalake.swaggerlog.config.Artifact;
 import com.sonalake.swaggerlog.config.Config;
 import com.sonalake.swaggerlog.config.Target;
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -26,14 +30,14 @@ import static org.powermock.api.mockito.PowerMockito.*;
 @PrepareForTest(Unirest.class)
 public class ScannerTest {
 
-  public static final String GROUP_ID = "a";
-  public static final String ARTIFACT_ID = "b";
-  public static final String CLASSIFIER_ID = "c";
+  public static final String GROUP_ID = "com.sonalake";
+  public static final String ARTIFACT_ID = "order-state-service";
+  public static final String CLASSIFIER_ID = "openapi";
 
   @Test
-  public void test() throws Exception {
+  public void testV2() throws Exception {
 
-    GetRequest request = givenNexusResponse("{ \"data\": [" + artifact("a", "b", "1.2.3") + "," + artifact("a", "b", "1.1") + "] }");
+    GetRequest request = givenNexusResponse(fromResource("results.v2.json"));
 
     // given this config
     List<VersionStep> history = Scanner.builder()
@@ -57,14 +61,21 @@ public class ScannerTest {
     assertEquals(2, history.size());
     assertEquals(
       VersionStep.builder()
-        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.1").build())
-        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.2.3").build())
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID)
+          .version("1.0.1")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.json")
+          .build())
         .build(),
       history.get(0)
     );
     assertEquals(
       VersionStep.builder()
-        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.2.3").build())
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.json")
+          .build())
         .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).path("snapshot-file").build())
         .build(),
       history.get(1)
@@ -73,8 +84,8 @@ public class ScannerTest {
 
 
   @Test
-  public void testWithClassifier() throws Exception {
-    GetRequest request = givenNexusResponse("{ \"data\": [" + artifact("a", "b", "1.2.3") + "," + artifact("a", "b", "1.1") + "] }");
+  public void testWithClassifierV2() throws Exception {
+    GetRequest request = givenNexusResponse(fromResource("results.v2.json"));
 
     // given this config
     List<VersionStep> history = Scanner.builder()
@@ -85,6 +96,7 @@ public class ScannerTest {
           .classifier(CLASSIFIER_ID)
           .build())
         .nexusHome("http://nexus/there")
+        .repositoryId("releases")
         .target(Target.builder().targetdir("/tmp/here").build())
         .snapshotVersionFile("snapshot-file")
         .build())
@@ -100,18 +112,28 @@ public class ScannerTest {
     assertEquals(2, history.size());
     assertEquals(
       VersionStep.builder()
-        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.1").build())
-        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.2.3").build())
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.1")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
         .build(),
       history.get(0)
     );
     assertEquals(
       VersionStep.builder()
-        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.2.3").build())
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
         .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).path("snapshot-file").build())
         .build(),
       history.get(1)
     );
+  }
+
+  private String fromResource(String name) throws IOException {
+    return IOUtils.toString(currentThread().getContextClassLoader().getResource(name), StandardCharsets.UTF_8);
   }
 
   @Test
@@ -136,50 +158,10 @@ public class ScannerTest {
       .build()
       .getHistory());
 
-    assertEquals(error.getMessage(), format("Failed to parse results from nexus: %s", config));
+    assertEquals(format("Failed to parse results from nexus: %s", config), error.getMessage());
   }
 
-  @Test
-  public void testVersionUri() {
-    Scanner scanner = Scanner.builder().config(
-      Config.builder()
-        .nexusHome("http://atlanta.sonalake.corp:8081/nexus")
-        .repositoryId("releases")
-        .artifact(Artifact.builder().build())
-        .build()
-    ).build();
 
-    VersionedArtifact version = VersionedArtifact.builder()
-      .group("com.sonalake")
-      .artifact("esqt-server-API")
-      .version("1.0.1")
-      .build();
-
-    String observedUri = scanner.getVersionUri(version);
-    assertEquals("Wrong uri", "http://atlanta.sonalake.corp:8081/nexus/service/local/repositories/releases/content/com/sonalake/esqt-server-API/1.0.1/esqt-server-API-1.0.1.json", observedUri);
-  }
-
-  @Test
-  public void testVersionUriWithClassifier() {
-    Scanner scanner = Scanner.builder().config(
-      Config.builder()
-        .nexusHome("http://atlanta.sonalake.corp:8081/nexus")
-        .repositoryId("releases")
-        .artifact(Artifact.builder()
-          .classifier("openapi")
-          .build())
-        .build()
-    ).build();
-
-    VersionedArtifact version = VersionedArtifact.builder()
-      .group("com.sonalake")
-      .artifact("order-state-service")
-      .version("1.0.1")
-      .build();
-
-    String observedUri = scanner.getVersionUri(version);
-    assertEquals("Wrong uri", "http://atlanta.sonalake.corp:8081/nexus/service/local/repositories/releases/content/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json", observedUri);
-  }
 
 
   private GetRequest givenNexusResponse(String responseData) throws Exception {
@@ -200,4 +182,105 @@ public class ScannerTest {
 
     );
   }
+
+
+  @Test
+  public void testV3() throws Exception {
+
+    GetRequest request = givenNexusResponse(fromResource("results.v3.json"));
+
+    // given this config
+    List<VersionStep> history = Scanner.builder()
+      .config(Config.builder()
+        .isVersion3(true)
+        .artifact(Artifact.builder()
+          .groupId(GROUP_ID)
+          .artifactId(ARTIFACT_ID)
+          .build())
+        .nexusHome("http://nexus/there")
+        .target(Target.builder().targetdir("/tmp/here").build())
+        .snapshotVersionFile("snapshot-file")
+        .build())
+      .build()
+      .getHistory();
+
+    // then the query was valid
+    verify(request).queryString(eq("group"), eq(GROUP_ID));
+    verify(request).queryString(eq("maven.artifactId"), eq(ARTIFACT_ID));
+
+    // and the results parse ok
+    assertEquals(2, history.size());
+    assertEquals(
+      VersionStep.builder()
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID)
+          .version("1.0.1")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
+        .build(),
+      history.get(0)
+    );
+    assertEquals(
+      VersionStep.builder()
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).path("snapshot-file").build())
+        .build(),
+      history.get(1)
+    );
+  }
+
+  @Test
+  public void testV3WithClassifier() throws Exception {
+
+    GetRequest request = givenNexusResponse(fromResource("results.v3.json"));
+
+    // given this config
+    List<VersionStep> history = Scanner.builder()
+      .config(Config.builder()
+        .isVersion3(true)
+        .artifact(Artifact.builder()
+          .groupId(GROUP_ID)
+          .artifactId(ARTIFACT_ID)
+          .classifier(CLASSIFIER_ID)
+          .build())
+        .nexusHome("http://nexus/there")
+        .target(Target.builder().targetdir("/tmp/here").build())
+        .snapshotVersionFile("snapshot-file")
+        .build())
+      .build()
+      .getHistory();
+
+    // then the query was valid
+    verify(request).queryString(eq("group"), eq(GROUP_ID));
+    verify(request).queryString(eq("maven.artifactId"), eq(ARTIFACT_ID));
+
+    // and the results parse ok
+    assertEquals(2, history.size());
+    assertEquals(
+      VersionStep.builder()
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID)
+          .version("1.0.1")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
+        .build(),
+      history.get(0)
+    );
+    assertEquals(
+      VersionStep.builder()
+        .from(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).version("1.0.2")
+          .downloadFrom("http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json")
+          .build())
+        .to(VersionedArtifact.builder().group(GROUP_ID).artifact(ARTIFACT_ID).path("snapshot-file").build())
+        .build(),
+      history.get(1)
+    );
+  }
+
 }

--- a/src/test/resources/results.v2.json
+++ b/src/test/resources/results.v2.json
@@ -1,0 +1,61 @@
+{
+  "totalCount": 2,
+  "from": -1,
+  "count": -1,
+  "tooManyResults": false,
+  "collapsed": false,
+  "repoDetails": [
+    {
+      "repositoryId": "releases",
+      "repositoryName": "Releases",
+      "repositoryContentClass": "maven2",
+      "repositoryKind": "hosted",
+      "repositoryPolicy": "RELEASE",
+      "repositoryURL": "http://nexus/service/local/repositories/releases"
+    }
+  ],
+  "data": [
+    {
+      "groupId": "com.sonalake",
+      "artifactId": "order-state-service",
+      "version": "1.0.2",
+      "latestRelease": "1.0.2",
+      "latestReleaseRepositoryId": "releases",
+      "artifactHits": [
+        {
+          "repositoryId": "releases",
+          "artifactLinks": [
+            {
+              "extension": "pom"
+            },
+            {
+              "classifier": "openapi",
+              "extension": "json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "groupId": "com.sonalake",
+      "artifactId": "order-state-service",
+      "version": "1.0.1",
+      "latestRelease": "1.0.2",
+      "latestReleaseRepositoryId": "releases",
+      "artifactHits": [
+        {
+          "repositoryId": "releases",
+          "artifactLinks": [
+            {
+              "extension": "pom"
+            },
+            {
+              "classifier": "openapi",
+              "extension": "json"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/results.v3.json
+++ b/src/test/resources/results.v3.json
@@ -1,0 +1,161 @@
+{
+  "items": [
+    {
+      "id": "c2FtcGxlLXJlcG86ZDhjMjBmZWQwZWJlM2VlZjBmYjE0ZjQ3MjFhNzBhNTI",
+      "repository": "sample-repo",
+      "format": "maven2",
+      "group": "com.sonalake",
+      "name": "order-state-service",
+      "version": "1.0.1",
+      "assets": [
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json",
+          "id": "c2FtcGxlLXJlcG86ZDgzMzAwNWQ0OWMzNDhlODMzZmEyZGFkNzY5ZTAzZWU",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "345e595e0e22d8bb635bf8977a5fe1ee04c09715",
+            "sha256": "1ef2ed56af2d163c932c1d7bb5f1c9960716832f2fe664e10d457e4e1bcd46f3",
+            "sha512": "ac3c7960d5d149e1d0a0ca0fc004f0f834121fb35a4a407b034d0282f2a0c341c870ef79ebb5c7e31e08465007a00b4b17b85444d7c4a8839f0f097b14b33c70",
+            "md5": "591938b6b4c23d9fe767e5c7fe527837"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json.md5",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json.md5",
+          "id": "c2FtcGxlLXJlcG86YmQ3Zjc5ZTE5NjczMDUwODA3MWMwYzQyNjI5Zjg0ZGM",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "24d06f8e65be82c2cea12b68bad5c53a7993acda",
+            "md5": "b94d6a0b72121f8d823d6d2ce3fb3071"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json.sha1",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1-openapi.json.sha1",
+          "id": "c2FtcGxlLXJlcG86MjdiOTA0YmE0MzFkOWU1ZTBhNzU5MDc0NzAwYWUxZTM",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "66db2debdb5d9d9d46905500a63525d641c9fa64",
+            "md5": "39ac3de4bab392443c80590f1b8151a6"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom",
+          "id": "c2FtcGxlLXJlcG86ZjhiOWE3ZmEzZWYwN2FiMDg5OTlmZTJmODlmNTBhOWI",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "c42dddc9277471e26a2c2e5e6f57d6e1a969af8e",
+            "md5": "8b9f6a12aeef49d58eef500befbe2563"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom.md5",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom.md5",
+          "id": "c2FtcGxlLXJlcG86MWUwNjFhNDcxMTg2ZmVlZjcyODUxMWY4NTk1NGVlYjA",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "baef3f1c25cbcaa1e138507059e359a85309f02a",
+            "md5": "9558a733a37423f1a564035001470b1e"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom.sha1",
+          "path": "com/sonalake/order-state-service/1.0.1/order-state-service-1.0.1.pom.sha1",
+          "id": "c2FtcGxlLXJlcG86MjQ2YTBiNjc1ZDc3MTJmYmEzMmU5YmZiMjlhZGVhZjQ",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "4fa3beca70f0b18c9dd1fc40375d46c19d7fa333",
+            "md5": "61e5e98c08705f432d2fdd806c9cd713"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c2FtcGxlLXJlcG86M2NmYTU3ZjMwZTEzZTE4ZjI2MGY1ODY5YzUwM2EzN2M",
+      "repository": "sample-repo",
+      "format": "maven2",
+      "group": "com.sonalake",
+      "name": "order-state-service",
+      "version": "1.0.2",
+      "assets": [
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json",
+          "id": "c2FtcGxlLXJlcG86NGRhN2E3YWJiMGI0ODIwMzA4MDU5YTZiZGE0ODkzYTE",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "345e595e0e22d8bb635bf8977a5fe1ee04c09715",
+            "sha256": "1ef2ed56af2d163c932c1d7bb5f1c9960716832f2fe664e10d457e4e1bcd46f3",
+            "sha512": "ac3c7960d5d149e1d0a0ca0fc004f0f834121fb35a4a407b034d0282f2a0c341c870ef79ebb5c7e31e08465007a00b4b17b85444d7c4a8839f0f097b14b33c70",
+            "md5": "591938b6b4c23d9fe767e5c7fe527837"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json.md5",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json.md5",
+          "id": "c2FtcGxlLXJlcG86NDkzMWEyNDBjNWJhOTYxMTdkYTFmYTYwYmNjYWRjMzk",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "24d06f8e65be82c2cea12b68bad5c53a7993acda",
+            "md5": "b94d6a0b72121f8d823d6d2ce3fb3071"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json.sha1",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2-openapi.json.sha1",
+          "id": "c2FtcGxlLXJlcG86NjU2MTE5NDJlOTE2ZWJjN2ZlZDA4ZDI1NDgwMzkxMmU",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "66db2debdb5d9d9d46905500a63525d641c9fa64",
+            "md5": "39ac3de4bab392443c80590f1b8151a6"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom",
+          "id": "c2FtcGxlLXJlcG86ZDgzMzAwNWQ0OWMzNDhlOGZlYWZjOThiNjM1ZjFhNjY",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "2091fec7b9478fdfb049de1b61ad203bba47dedd",
+            "md5": "9e0f897d37139111076606f02d73cea7"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom.md5",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom.md5",
+          "id": "c2FtcGxlLXJlcG86YmQ3Zjc5ZTE5NjczMDUwOGY2MjEwM2I1ZjhmMTYxNjc",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "9ad40fb1042d42843bbaa10b888a13855bec2779",
+            "md5": "f00e62ebaa6fbf44e22dd49d891baefb"
+          }
+        },
+        {
+          "downloadUrl": "http://nexus/repository/sample-repo/com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom.sha1",
+          "path": "com/sonalake/order-state-service/1.0.2/order-state-service-1.0.2.pom.sha1",
+          "id": "c2FtcGxlLXJlcG86MjdiOTA0YmE0MzFkOWU1ZWNmZTJlYmIwNDNlYTY2YzE",
+          "repository": "sample-repo",
+          "format": "maven2",
+          "checksum": {
+            "sha1": "48dc0390ac92c5b62d1f7ff8280fb4ce5fb06a83",
+            "md5": "b15f1bd77984bb6082cc0f85e6875cde"
+          }
+        }
+      ]
+    }
+  ],
+  "continuationToken": null
+}


### PR DESCRIPTION
The API between V2 and V3 completely changed, so I've moved some stuff around to hide this from the rest of the code

- A new `isNexusVersion3` drives this. I've left the default behaviour to use the V2 API
- All the querying code is now down in the `VersionFinder` that knows how to build a query for the two APIs and passes the json response we get back to jackson, that then dumps them into one of these two classes
   - `V3NexusResult` - this result set is nice, in that it contains the links for downloading what it finds
   - `V2NexusResult` - this result set is a bit more complex, in that we need to derive the URL from a few different parts of the response
- Updated some tests